### PR TITLE
fix: Make contacts section visible and fix layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 
         <section id="contacts" class="section contacts__section">
             <div class="container contacts__container">
-                <div class="contacts__info fade-in">
+                <div class="contacts__info">
                     <h2 class="section__title">Свяжитесь с нами</h2>
                     <p class="section__text">Мы всегда рады ответить на ваши вопросы и помочь с выбором процедуры. Запишитесь на ритуал релаксации уже сегодня.</p>
                     <ul class="contacts__list">
@@ -94,7 +94,7 @@
                         <li><strong>Режим работы:</strong> Пн-Пт с 10:00 до 20:00</li>
                     </ul>
                 </div>
-                <div class="contacts__map fade-in" id="map"></div>
+                <div class="contacts__map" id="map"></div>
             </div>
         </section>
     </main>


### PR DESCRIPTION
This commit fixes a critical bug where the Contacts section and map were not visible, and the page layout was broken.

The root cause was a `fade-in` class applied to elements within the section, which set their opacity to 0. The JavaScript logic responsible for making them visible via an IntersectionObserver had been removed in a previous refactor, leaving the elements permanently invisible.

This fix removes the unnecessary `fade-in` classes from the `index.html` file, making the Contacts section and the Yandex.Map render correctly by default. The layout and scrolling issues are now resolved.