### PR TITLE
fix: Reduce section icon size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -192,8 +192,8 @@ main { padding-top: var(--space-10); } /* 80px */
 .section__icon {
     display: block;
     margin: 0 auto var(--space-4);
-    width: 80px;
-    height: 80px;
+    width: 56px;
+    height: 56px;
     opacity: 0.9;
     animation: fadeIn-down 1s ease-out .2s;
     animation-fill-mode: backwards;


### PR DESCRIPTION
Based on user feedback, the section icons were too large. This commit reduces the size of the `.section__icon` from 80px to 56px to make them fit more harmoniously within the overall design.