### PR TITLE
fix: Resolve mobile menu issues and add logo

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -370,6 +370,7 @@ html[data-theme="dark"] .contacts__map { filter: invert(1) hue-rotate(180deg) br
     .nav.active {
         opacity: 1;
         visibility: visible;
+        pointer-events: auto;
         transition: opacity 0.3s ease;
     }
     .nav__link {
@@ -387,6 +388,15 @@ html[data-theme="dark"] .contacts__map { filter: invert(1) hue-rotate(180deg) br
     .nav.active .nav__link:nth-child(2) { transition-delay: 0.3s; }
     .nav.active .nav__link:nth-child(3) { transition-delay: 0.4s; }
     .nav.active .nav__link:nth-child(4) { transition-delay: 0.5s; }
+    .nav__logo {
+        position: absolute;
+        bottom: var(--space-6);
+        opacity: 0;
+        transition: opacity 0.5s ease 0.6s;
+    }
+    .nav.active .nav__logo {
+        opacity: 1;
+    }
     .burger { display: block; }
     .contacts__container, .reviews-grid { grid-template-columns: 1fr; }
 }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
                 <a href="#services" class="nav__link">Услуги</a>
                 <a href="#reviews" class="nav__link">Отзывы</a>
                 <a href="#contacts" class="nav__link">Контакты</a>
+                <a href="#" class="logo nav__logo">Li</a>
             </nav>
             <div class="header__actions">
                 <button class="theme-toggle" id="theme-toggle" aria-label="Переключить тему">


### PR DESCRIPTION
This commit addresses the final user feedback regarding the mobile menu.

- Fixes a regression where the mobile menu navigation links were not clickable. This was resolved by adding `pointer-events: auto;` to the `.nav.active` CSS rule.
- Adds the site logo to the bottom of the mobile navigation menu, as requested. The logo fades in after the main navigation links for a polished effect.