### PR TITLE
fix: Adjust styling for owner photo in About section

### DIFF
--- a/assets/css/style-v2.css
+++ b/assets/css/style-v2.css
@@ -272,7 +272,7 @@ section[id] {
 
 .about__photo {
     width: 100%;
-    max-width: 320px; /* A bit smaller to fit nicely */
+    max-width: 800px; /* Match width of text block above */
     border-radius: var(--border-radius);
     box-shadow: var(--shadow-lg);
     object-fit: cover;


### PR DESCRIPTION
This commit increases the max-width of the owner's photo in the "About" section to 800px to match the width of the text block above it, creating a more balanced and harmonious layout as per the user's request.